### PR TITLE
Make RestRequestListener to try to resolve RestRequestOptions on kernel.request also

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ build/
 phpunit.xml
 composer.lock
 bin/
+var/
 !bin/update-constraints-to-lowest.php

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.1.0]
 ### Changed
-- `RestRequestListener` will not try to resolve `RestRequestOptions` on `kernel.request` event after resolving route configuration.
+- When using annotations, `RestRequestOptions` will now be available after `kernel.request` event instead of `kernel.controller` one. This allows to show proper REST errors when exceptions are raised in the firewall.
 
 ## [1.0.0]
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0]
+### Changed
+- `RestRequestListener` will not try to resolve `RestRequestOptions` on `kernel.request` event after resolving route configuration.
+
 ## [1.0.0]
 ### Changed
 - `ErrorNormalizer` does not return keys with `null` values anymore.

--- a/src/Resources/config/services/listeners.xml
+++ b/src/Resources/config/services/listeners.xml
@@ -26,6 +26,7 @@
         <service class="Paysera\Bundle\ApiBundle\Listener\RestRequestListener"
                  id="paysera_api.listener.rest_request">
             <tag name="kernel.event_listener" event="kernel.controller"/>
+            <tag name="kernel.event_listener" event="kernel.request" priority="31"/>
 
             <argument id="paysera_normalization.core_denormalizer" type="service"/>
             <argument id="security.authorization_checker" type="service"/>

--- a/src/Service/RestRequestHelper.php
+++ b/src/Service/RestRequestHelper.php
@@ -28,26 +28,43 @@ class RestRequestHelper
     }
 
     /**
-     * Resolves REST related options for current request.
-     * If request is configured for REST support, returns null.
+     * Resolves REST related options for current route.
+     * If request is configured for via annotations for REST support, returns RestRequestOptions.
      *
      * @param Request $request
-     * @param callable $controller
-     * @return null|RestRequestOptions
+     *
+     * @return RestRequestOptions|null
      *
      * @internal
      */
-    public function resolveRestRequestOptions(Request $request, callable $controller)
+    public function resolveRestRequestOptionsForRequest(Request $request)
     {
         $serialized = $request->attributes->get(self::SERIALIZED_REST_OPTIONS_KEY);
         if ($serialized !== null) {
             return unserialize($serialized);
         }
 
+        return null;
+    }
+
+    /**
+     * Resolves REST related options for current request.
+     * If request is configured via custom configuration for REST support, returns RestRequestOptions.
+     *
+     * @param Request $request
+     * @param callable $controller
+     *
+     * @return RestRequestOptions|null
+     *
+     * @internal
+     */
+    public function resolveRestRequestOptionsForController(Request $request, callable $controller)
+    {
         $controllerIdentifier = $request->attributes->get('_controller');
         $options = $controllerIdentifier !== null
             ? $this->restRequestOptionsRegistry->getRestRequestOptionsForController($controllerIdentifier)
-            : null;
+            : null
+        ;
         if ($options !== null) {
             return $options;
         }
@@ -60,6 +77,7 @@ class RestRequestHelper
             $options = $this->restRequestOptionsRegistry->getRestRequestOptionsForController(
                 implode('::', $controllerAsArray)
             );
+
             return $options;
         }
 
@@ -90,7 +108,8 @@ class RestRequestHelper
 
     /**
      * Returns whether this is REST configured request.
-     * Only works after setting Options – use resolveRestRequestOptions before that
+     * Only works after setting Options – use either
+     * resolveRestRequestOptionsForController or resolveRestRequestOptionsForRequest before that
      *
      * @param Request $request
      * @return bool

--- a/src/Service/RestRequestHelper.php
+++ b/src/Service/RestRequestHelper.php
@@ -108,8 +108,7 @@ class RestRequestHelper
 
     /**
      * Returns whether this is REST configured request.
-     * Only works after setting Options – use either
-     * resolveRestRequestOptionsForController or resolveRestRequestOptionsForRequest before that
+     * Only works after setting options in kernel.request or kernel.controller
      *
      * @param Request $request
      * @return bool

--- a/tests/Unit/Service/RestRequestHelperTest.php
+++ b/tests/Unit/Service/RestRequestHelperTest.php
@@ -26,7 +26,7 @@ class RestRequestHelperTest extends MockeryTestCase
 
         $request = new Request();
         $request->attributes->add($route->getDefaults());
-        $options = $helper->resolveRestRequestOptions($request, function () {});
+        $options = $helper->resolveRestRequestOptionsForRequest($request);
         $this->assertEquals($originalOptions, $options);
     }
 
@@ -60,7 +60,7 @@ class RestRequestHelperTest extends MockeryTestCase
 
         $request = new Request();
 
-        $this->assertNull($helper->resolveRestRequestOptions($request, function () {}));
+        $this->assertNull($helper->resolveRestRequestOptionsForRequest($request));
     }
 
     public function testResolveRestRequestOptionsWithRegisteredOptionsAndCustomController()
@@ -80,7 +80,7 @@ class RestRequestHelperTest extends MockeryTestCase
             ->andReturn($options)
         ;
 
-        $this->assertSame($options, $helper->resolveRestRequestOptions($request, function () {}));
+        $this->assertSame($options, $helper->resolveRestRequestOptionsForController($request, function () {}));
     }
 
     public function testResolveRestRequestOptionsWithRegisteredOptionsAndClassController()
@@ -106,7 +106,7 @@ class RestRequestHelperTest extends MockeryTestCase
             ->andReturn($options)
         ;
 
-        $this->assertSame($options, $helper->resolveRestRequestOptions(
+        $this->assertSame($options, $helper->resolveRestRequestOptionsForController(
             $request,
             ['DateTimeImmutable', 'createFromFormat']
         ));


### PR DESCRIPTION
# Description

In some cases application needs to have rest options resolved before making it to `kernel.controller` event.
For example, making an unauthorized request to API, while having `twig` bundle configured in application, will duplicate the request and change controller. In these cases, `RestExceptionListener` will not be able to resolve the correct configuration, because it will not exist anymore.

To solve this problem we need to set `RestRequestOptions` immediately after resolving route's configuration.  