### PR TITLE
AC-282: Fix deprecation messages for Symfony 6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
           - '8.0'
           - '8.1'
           - '8.2'
+          - '8.3'
         symfony:
           - '3.*'
           - '4.*'
@@ -38,6 +39,7 @@ jobs:
           - { php: '8.0', symfony: '3.*' }
           - { php: '8.1', symfony: '3.*' }
           - { php: '8.2', symfony: '3.*' }
+          - { php: '8.3', symfony: '3.*' }
           - { php: '7.1', symfony: '5.*' }
           - { php: '7.1', symfony: '6.*' }
           - { php: '7.2', symfony: '6.*' }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.1]
+### Added
+- `void` typehint to `PayseraApiBundle::build` method
+- PHP 8.3 to CI
+
 ## [1.8.0]
 ### Added
 - Support for PHP 8 attributes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.8.1]
 ### Added
-- `void` typehint to `PayseraApiBundle::build` method
+- `void` typehint to `PayseraApiBundle::build` method to fix the deprecation message
 - PHP 8.3 to CI
+### Fixed
+- `Call to a member function getClassAnnotations() on null` error in `RoutingAttributeLoader` on Symfony 6
 
 ## [1.8.0]
 ### Added

--- a/src/Listener/RestResponseListener.php
+++ b/src/Listener/RestResponseListener.php
@@ -65,7 +65,7 @@ class RestResponseListener
     {
         $includedFields = [];
         $fields = $request->query->get('fields');
-        if ($fields !== null && is_string($fields) && $fields !== '') {
+        if (is_string($fields) && $fields !== '') {
             $includedFields = explode(',', $fields);
         }
 

--- a/src/PayseraApiBundle.php
+++ b/src/PayseraApiBundle.php
@@ -9,7 +9,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class PayseraApiBundle extends Bundle
 {
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         parent::build($container);
 

--- a/src/Service/RoutingLoader/RoutingAttributeLoader.php
+++ b/src/Service/RoutingLoader/RoutingAttributeLoader.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Paysera\Bundle\ApiBundle\Service\RoutingLoader;
 
-use Doctrine\Common\Annotations\Reader;
 use Paysera\Bundle\ApiBundle\Annotation\RestAnnotationInterface;
 use Paysera\Bundle\ApiBundle\Attribute\RestAttributeInterface;
 use Paysera\Bundle\ApiBundle\Service\RestRequestHelper;
@@ -62,7 +61,7 @@ class RoutingAttributeLoader extends AttributeRouteControllerLoader
 
     private function loadAnnotations(Route $route, ReflectionClass $class, ReflectionMethod $method): void
     {
-        if (!isset($this->reader) || !$this->reader instanceof Reader) {
+        if (!isset($this->reader)) {
             return;
         }
 

--- a/src/Service/RoutingLoader/RoutingAttributeLoader.php
+++ b/src/Service/RoutingLoader/RoutingAttributeLoader.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Paysera\Bundle\ApiBundle\Service\RoutingLoader;
 
+use Doctrine\Common\Annotations\Reader;
 use Paysera\Bundle\ApiBundle\Annotation\RestAnnotationInterface;
 use Paysera\Bundle\ApiBundle\Attribute\RestAttributeInterface;
 use Paysera\Bundle\ApiBundle\Service\RestRequestHelper;
@@ -61,6 +62,10 @@ class RoutingAttributeLoader extends AttributeRouteControllerLoader
 
     private function loadAnnotations(Route $route, ReflectionClass $class, ReflectionMethod $method): void
     {
+        if (!isset($this->reader) || !$this->reader instanceof Reader) {
+            return;
+        }
+
         $annotations = [];
         foreach ($this->reader->getClassAnnotations($class) as $annotation) {
             if ($annotation instanceof RestAnnotationInterface) {


### PR DESCRIPTION
1. A `void` typehint for PayseraApiBundle::build was added to fix the deprecation message:

`PHP Deprecated: Method "Symfony\Component\HttpKernel\Bundle\Bundle::build()" might add "void" as a native return type declaration in the future. Do the same in child class "Paysera\Bundle\ApiBundle\PayseraApiBundle" now to avoid errors or add an explicit @return annotation to suppress this message. in /home/app/src/vendor/symfony/error-handler/DebugClassLoader.php on line 339`


2. Annotations get deprecated completely and `AttributeClassLoader` doesn't have `$reader` property anymore.

Symfony 6.4 - https://github.com/symfony/routing/blob/6.4/Loader/AttributeClassLoader.php#L83
Symfony 7.2 - https://github.com/symfony/routing/blob/7.2/Loader/AttributeClassLoader.php#L54

But it's called inside `Paysera\Bundle\ApiBundle\Service\RoutingLoader\RoutingAttributeLoader` causing error `Call to a member function getClassAnnotations() on null`.

A check was added not to call the `$reader` if it doesn't exist of is not an instance of `Doctrine\Common\Annotations\Reader`.